### PR TITLE
Include the root project in the analysis, too

### DIFF
--- a/src/main/scala/sbtwhitesource/WhiteSourcePlugin.scala
+++ b/src/main/scala/sbtwhitesource/WhiteSourcePlugin.scala
@@ -154,7 +154,7 @@ object WhiteSourcePlugin extends AutoPlugin {
         ).execute()
   )
 
-  private val thisProjectAggregates = ScopeFilter(inAggregates(ThisProject, includeRoot = false))
+  private val thisProjectAggregates = ScopeFilter(inAggregates(ThisProject, includeRoot = true))
 
   private val whitesourceConfig = Def task new Config(
     projectID.value,


### PR DESCRIPTION
Particularly useful for projects that do not use subprojects, such as
akka-persistence-dynamodb